### PR TITLE
added arm64 support

### DIFF
--- a/SecurityCheck.xcodeproj/project.pbxproj
+++ b/SecurityCheck.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -257,6 +258,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/SecurityCheck/libASM.h
+++ b/SecurityCheck/libASM.h
@@ -6,7 +6,21 @@
 // WARNING: These functions don't allow more than 4 arguments in each function.
 // For more than 4 arguments, you need a stack frame for arguments after the 4th.
 
-#if defined(__arm__)
+#if defined(__LP64__)
+
+.macro BEGIN_FUNCTION
+    .align 2           // Align the function code to a 8-byte (2^n) word boundary.
+    .globl _$0			// Make the function globally accessible.
+    .no_dead_strip _$0	// Stop the optimizer from ignoring this function!
+    .private_extern _$0
+_$0:					// Declare the function.
+.endmacro
+
+.macro END_FUNCTION
+    ret
+.endmacro
+
+#elif defined(__arm__)
 
 .macro BEGIN_FUNCTION
 	.align 2			// Align the function code to a 4-byte (2^n) word boundary.

--- a/SecurityCheck/readSys.s
+++ b/SecurityCheck/readSys.s
@@ -1,6 +1,42 @@
 #include "libASM.h"
 
-//------ ARM registers used:
+#if defined(__LP64__)
+
+//------ AArch64 registers used:
+//
+// x0-x7        input/result
+// x18          platform        save
+// x19-x28      callee saved    save
+// x29(FP)      frame pointer   save
+// x30(LR)      link reg        save
+//
+// d8-d15       callee saved    save
+//
+
+BEGIN_FUNCTION readSys
+    // I don't think this needs more registers saved/restored in prologue/epilogue?
+    // Caller should have saved any needed, and sysctl will save any callee-saved.
+    // x16 is assumed caller saved already
+    // x4-x5 are parameter registers, and we only need to expect x0-x3 for sysctl,
+    // so we should be able zero x4-x5 safely
+
+    // prologue
+    stp fp, lr, [sp, #-16]!
+    add fp, sp, #0
+
+    mov     x4, #0
+    mov     x5, #0
+    mov     x16, #202
+    svc     #128
+
+    //epilogue
+    ldp fp, lr, [sp], #16                   // restore state
+
+END_FUNCTION
+
+#elif defined(__arm__)
+
+//------ AArch32 registers used:
 // r0:	arg0 & result (input & output parameters)
 // r1:	arg1 (input parameter)
 // r2:
@@ -17,9 +53,6 @@
 // r13:		* Stack Pointer (dont touch!)
 // r14:		(must restore if modified)
 // r15:		* Program Counter (dont touch!)
-//
-
-#if defined(__arm__)
 
 BEGIN_FUNCTION readSys
     // ---------------


### PR DESCRIPTION
(see comment in readSys.s) Not 100% on register saving/restoring. Currently only save/reload the frame pointer and link register since our function doesn't overwrite any callee-saved registers. We assume any caller-saved are already saved and our `svc` call respects callee-saving convention.
