### PR TITLE
Updated header files with proper legalese

### DIFF
--- a/SecurityCheck/SecurityCheck.h
+++ b/SecurityCheck/SecurityCheck.h
@@ -3,7 +3,7 @@
 //  SecurityCheck
 //
 //  Created by ct on 2/26/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #ifndef SecurityCheck_SecurityCheck_h

--- a/SecurityCheck/debugCheck.h
+++ b/SecurityCheck/debugCheck.h
@@ -2,7 +2,7 @@
 //  debugCheck.h
 //
 //  Created by ct on 1/30/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #ifndef debugMe_dbgChk_h

--- a/SecurityCheck/debugCheckTemplate.h
+++ b/SecurityCheck/debugCheckTemplate.h
@@ -3,7 +3,7 @@
 //  SecurityCheck
 //
 //  Created by ct on 2/14/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #import <UIKit/UIKit.h>

--- a/SecurityCheck/fileCheck.h
+++ b/SecurityCheck/fileCheck.h
@@ -3,7 +3,7 @@
 //  SecurityCheck
 //
 //  Created by ct on 2/26/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #ifndef SecurityCheck_FileCheck_h

--- a/SecurityCheck/forkCheck.h
+++ b/SecurityCheck/forkCheck.h
@@ -3,7 +3,7 @@
 //  SecurityCheck
 //
 //  Created by ct on 2/26/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #ifndef SecurityCheck_forkCheck_h

--- a/SecurityCheck/jailbreakCheckTemplate.h
+++ b/SecurityCheck/jailbreakCheckTemplate.h
@@ -3,7 +3,7 @@
 //  SecurityCheck
 //
 //  Created by ct on 2/26/13.
-//  Copyright (c) 2013 MITRE. All rights reserved.
+//  Copyright (c) 2013 The MITRE Corporation. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
We at the Patient Toolkit are using Security Check and prepping for release to TestFlight. Apparently MITRE legal cares about the specific format of the copyright on the header files? So I went ahead and fixed them in your headers. Would you mind pulling in this most minor of minor changes?